### PR TITLE
Only log variables for graphql requests that are below a threshold in logger middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 1.3.0
 
-Don't add `variables` to `meta.graphql` in the middleware logger. It is possible
-that `variables` is a big object that could bloat the payload.
+Don't add `variables` to `meta.graphql` in the middleware logger when disabled
+via `logGraphqlVariables: false`. It's possible that `variables` is a big object that could bloat the payload.
 
 ## 1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 1.3.0
 
-Don't add `variables` to `meta.graphql` in the middleware logger when disabled
-via `logGraphqlVariables: false`. It's possible that `variables` is a big object that could bloat the payload.
+Limit the size of logged `variables` for `meta.graphql` in the middleware logger
+via `maxGraphQLVariablesLength`. It's possible that `variables` is a big object that could bloat the payload.
 
 ## 1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.0
+
+Don't add `variables` to `meta.graphql` in the middleware logger. It is possible
+that `variables` is a big object that could bloat the payload.
+
 ## 1.2.0
 
 Add handling for `requestId` ([#18](https://github.com/molindo/molindo-node-logger/pull/18))

--- a/README.md
+++ b/README.md
@@ -42,10 +42,6 @@ In production, printed JSON will look like this (except that it's not pretty pri
 If you're running an express server, you can register the logger middleware to
 log HTTP requests. GraphQL requests get automatically detected and attached as
 `meta.graphql`, with properties `operationName` and the respective `variables`.
-To limit the size of the pyload for the logged variables, you can pass a
-`maxGraphQLVariablesLength` (default `512`) parameter to
-`createLoggerMiddleware({logger, maxGraphQLVariablesLength=128})`. Setting it
-to `maxGraphQLVariablesLength=0` disables the limit.
 
 ```js
 import express from 'express';
@@ -56,3 +52,12 @@ const server = express();
 const logger = new Logger({service: 'pizza-shop'});
 server.use(createLoggerMiddleware({logger}));
 ```
+
+The size of `meta.graphql.variables` can sometimes grow too large to log
+effectively. To manage this, the middleware provides a configurable parameter:
+`maxGraphQLVariablesLength`.
+
+#### Configuration maxGraphQLVariablesLength
+* Set `maxGraphQLVariablesLength` (default: 512), to set the maximum size of the `meta.graphql.variables` payload to be logged.
+* Set `maxGraphQLVariablesLength` to `0` to completely turn off logging for `meta.graphql.variables`.
+* Set `maxGraphQLVariablesLength` to `-1` to include the complete `meta.graphql.variables` payload without size restrictions.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ server.use(createLoggerMiddleware({logger}));
 ```
 
 The size of `meta.graphql.variables` can sometimes grow too large to log
-effectively. To manage this, the middleware provides a configurable parameter:
+effectively. To manage this, the `createLoggerMiddleware()` function provides a configurable parameter:
 `maxGraphQLVariablesLength`.
 
 #### Configuration maxGraphQLVariablesLength

--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ In production, printed JSON will look like this (except that it's not pretty pri
 If you're running an express server, you can register the logger middleware to
 log HTTP requests. GraphQL requests get automatically detected and attached as
 `meta.graphql`, with properties `operationName` and the respective `variables`.
-To limit the size of the logged variables, you can pass a
-`MAX_GRAPHQL_VARIABLES_LOG_LENGTH` (default `512`) parameter to
-`createLoggerMiddleware({logger, MAX_GRAPHQL_VARIABLES_LOG_LENGTH=128})`. 
+To limit the size of the pyload for the logged variables, you can pass a
+`maxGraphQLVariablesLength` (default `512`) parameter to
+`createLoggerMiddleware({logger, maxGraphQLVariablesLength=128})`. Setting it
+to `maxGraphQLVariablesLength=0` disables the limit.
 
 ```js
 import express from 'express';

--- a/README.md
+++ b/README.md
@@ -39,7 +39,12 @@ In production, printed JSON will look like this (except that it's not pretty pri
 
 ### Express integration
 
-If you're running an express server, you can register the logger middleware to log HTTP requests.
+If you're running an express server, you can register the logger middleware to
+log HTTP requests. GraphQL requests get automatically detected and attached as
+`meta.graphql`, with properties `operationName` and the respective `variables`.
+To limit the size of the logged variables, you can pass a
+`MAX_GRAPHQL_VARIABLES_LOG_LENGTH` (default `512`) parameter to
+`createLoggerMiddleware({logger, MAX_GRAPHQL_VARIABLES_LOG_LENGTH=128})`. 
 
 ```js
 import express from 'express';

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The size of `meta.graphql.variables` can sometimes grow too large to log
 effectively. To manage this, the `createLoggerMiddleware()` function provides a configurable parameter:
 `maxGraphQLVariablesLength`.
 
-#### Configuration maxGraphQLVariablesLength
+#### Configuration of `maxGraphQLVariablesLength`
 * Set `maxGraphQLVariablesLength` (default: 512), to set the maximum size of the `meta.graphql.variables` payload to be logged.
 * Set `maxGraphQLVariablesLength` to `0` to completely turn off logging for `meta.graphql.variables`.
 * Set `maxGraphQLVariablesLength` to `-1` to include the complete `meta.graphql.variables` payload without size restrictions.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "molindo-node-logger",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A node.js logger that integrates well with the Molindo infrastructure.",
   "main": "lib/index.js",
   "repository": "https://github.com/molindo/molindo-node-logger.git",

--- a/src/__tests__/createLoggerMiddleware-test.js
+++ b/src/__tests__/createLoggerMiddleware-test.js
@@ -3,11 +3,11 @@ import supertest from 'supertest';
 import Logger from '../Logger';
 import createLoggerMiddleware from '../createLoggerMiddleware';
 
-const createServer = (logger, {MAX_GRAPHQL_VARIABLES_LOG_LENGTH} = {}) => {
+const createServer = (logger, {maxGraphQLVariablesLength} = {}) => {
   const server = express();
 
   server.use(
-    createLoggerMiddleware({logger, MAX_GRAPHQL_VARIABLES_LOG_LENGTH})
+    createLoggerMiddleware({logger, maxGraphQLVariablesLength})
   );
   server.get('/', (req, res) => res.json({success: true}));
   server.get('/500', () => {
@@ -177,7 +177,7 @@ describe('createLoggerMiddleware', () => {
 
   it('does not log graphql variables when disabled', async () => {
     const logger = new Logger({service: 'pizza-shop', isProduction: true});
-    const server = createServer(logger, {MAX_GRAPHQL_VARIABLES_LOG_LENGTH: 12});
+    const server = createServer(logger, {maxGraphQLVariablesLength: 12});
 
     await supertest(server).get('/');
     await supertest(server).get('/404');

--- a/src/__tests__/createLoggerMiddleware-test.js
+++ b/src/__tests__/createLoggerMiddleware-test.js
@@ -142,8 +142,7 @@ describe('createLoggerMiddleware', () => {
 
     expect(stdoutCalls[2].level).toBe('DEBUG');
     expect(stdoutCalls[2].meta.graphql).toEqual({
-      operationName: 'createPizza',
-      variables: {pizza: {toppings: ['salami']}}
+      operationName: 'createPizza'
     });
 
     const stderrCalls = process.stderr.write.mock.calls.map(call =>

--- a/src/createLoggerMiddleware.js
+++ b/src/createLoggerMiddleware.js
@@ -11,7 +11,7 @@ expressWinston.responseWhitelist.push('body');
 const MASKED_HEADERS = ['Cookie', 'cookie', 'Authorization', 'authorization'];
 const MASKED_HEADER_VALUE = '*****';
 
-export default ({logger}) => {
+export default ({logger, logGraphqlVariables = true}) => {
   const router = new Router();
   return router.use(
     bodyParser.json(),
@@ -33,7 +33,8 @@ export default ({logger}) => {
 
         if (req.method === 'POST' && req.body && req.body.operationName) {
           meta.graphql = {
-            operationName: req.body.operationName
+            operationName: req.body.operationName,
+            ...(logGraphqlVariables ? {variables: req.body.variables} : null)
           };
         }
 

--- a/src/createLoggerMiddleware.js
+++ b/src/createLoggerMiddleware.js
@@ -33,8 +33,7 @@ export default ({logger}) => {
 
         if (req.method === 'POST' && req.body && req.body.operationName) {
           meta.graphql = {
-            operationName: req.body.operationName,
-            variables: req.body.variables
+            operationName: req.body.operationName
           };
         }
 

--- a/src/createLoggerMiddleware.js
+++ b/src/createLoggerMiddleware.js
@@ -32,10 +32,16 @@ export default ({logger, maxGraphQLVariablesLength = 512}) => {
         const meta = {name: 'express'};
 
         if (req.method === 'POST' && req.body && req.body.operationName) {
-          let variables;
+          let variables = undefined;
 
-          if (maxGraphQLVariablesLength > 0) {
+          if (maxGraphQLVariablesLength === -1) {
+            variables = req.body.variables;
+          } else if (maxGraphQLVariablesLength === 0) {
+            // Keep variables undefined
+            variables = undefined;
+          } else if (maxGraphQLVariablesLength > 0) {
             const stringifiedVariables = JSON.stringify(req.body.variables);
+
             const isTooLarge =
               stringifiedVariables.length > maxGraphQLVariablesLength;
 
@@ -47,8 +53,6 @@ export default ({logger, maxGraphQLVariablesLength = 512}) => {
             } else {
               variables = req.body.variables;
             }
-          } else {
-            variables = req.body.variables;
           }
 
           meta.graphql = {

--- a/src/createLoggerMiddleware.js
+++ b/src/createLoggerMiddleware.js
@@ -11,7 +11,7 @@ expressWinston.responseWhitelist.push('body');
 const MASKED_HEADERS = ['Cookie', 'cookie', 'Authorization', 'authorization'];
 const MASKED_HEADER_VALUE = '*****';
 
-export default ({logger, MAX_GRAPHQL_VARIABLES_LOG_LENGTH = 512}) => {
+export default ({logger, maxGraphQLVariablesLength = 512}) => {
   const router = new Router();
   return router.use(
     bodyParser.json(),
@@ -34,16 +34,16 @@ export default ({logger, MAX_GRAPHQL_VARIABLES_LOG_LENGTH = 512}) => {
         if (req.method === 'POST' && req.body && req.body.operationName) {
           let variables;
 
-          if (MAX_GRAPHQL_VARIABLES_LOG_LENGTH > 0) {
+          if (maxGraphQLVariablesLength >= 0) {
             const stringifiedVariables = JSON.stringify(req.body.variables);
             const isTooLarge =
-              stringifiedVariables.length > MAX_GRAPHQL_VARIABLES_LOG_LENGTH;
+              stringifiedVariables.length > maxGraphQLVariablesLength;
 
             if (isTooLarge) {
               variables = `${stringifiedVariables.substring(
                 0,
-                MAX_GRAPHQL_VARIABLES_LOG_LENGTH
-              )} […] max payload length reached (${MAX_GRAPHQL_VARIABLES_LOG_LENGTH} chars)`;
+                maxGraphQLVariablesLength
+              )} […] max payload length reached (${maxGraphQLVariablesLength} chars)`;
             } else {
               variables = req.body.variables;
             }

--- a/src/createLoggerMiddleware.js
+++ b/src/createLoggerMiddleware.js
@@ -34,7 +34,7 @@ export default ({logger, maxGraphQLVariablesLength = 512}) => {
         if (req.method === 'POST' && req.body && req.body.operationName) {
           let variables;
 
-          if (maxGraphQLVariablesLength >= 0) {
+          if (maxGraphQLVariablesLength > 0) {
             const stringifiedVariables = JSON.stringify(req.body.variables);
             const isTooLarge =
               stringifiedVariables.length > maxGraphQLVariablesLength;


### PR DESCRIPTION
We currently log `graphql.variables` in the middleware which can result in a big logger payload (e.g ui-editor `featured` content variables contain full news articles).

Although we are on `v2` with `molindo-node-logger`, i need to keep v1 alive because we still use v1 in some apps.
For backwards compatibility i added a config variable `logGraphqlVariables` that disables variable logging.